### PR TITLE
Update for Jekyll 3.5

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: 404
+title: "404"
 permalink: /404.html
 ---
 

--- a/site/_includes/agent-list.html
+++ b/site/_includes/agent-list.html
@@ -5,19 +5,19 @@
       {% if agent.ref contains "corporate_entities" %}
         {% assign type = "organizations" %}
         {% capture id %}{{agent.ref | replace: '/agents/corporate_entities/', '' }}{% endcapture %}
-        {% assign agent_detail = site.data.agents.corporate_entities[{{id}}] %}
+        {% assign agent_detail = site.data.agents.corporate_entities[id] %}
       {% elsif agent.ref contains "families" %}
         {% assign type = "families" %}
         {% capture id %}{{agent.ref | replace: '/agents/families/', '' }}{% endcapture %}
-        {% assign agent_detail = site.data.agents.families[{{id}}] %}
+        {% assign agent_detail = site.data.agents.families[id] %}
       {% elsif agent.ref contains "people" %}
         {% assign type = "people" %}
         {% capture id %}{{agent.ref | replace: '/agents/people/', '' }}{% endcapture %}
-        {% assign agent_detail = site.data.agents.people[{{id}}] %}
+        {% assign agent_detail = site.data.agents.people[id] %}
       {% elsif agent.ref contains "software" %}
         {% assign type = "software" %}
         {% capture id %}{{agent.ref | replace: '/agents/software/', '' }}{% endcapture %}
-        {% assign agent_detail = site.data.agents.software[{{id}}] %}
+        {% assign agent_detail = site.data.agents.software[id] %}
       {% endif %}
   {% else %}
     <!-- no external .json file - just use agent as agent_detail -->

--- a/site/_includes/collections-json-ld.html
+++ b/site/_includes/collections-json-ld.html
@@ -18,19 +18,19 @@
           {% assign type = "organizations" %}
           {% assign label = "name" %}
           {% capture id %}{{agent.ref | replace: '/agents/corporate_entities/', '' }}{% endcapture %}
-          {% assign agent_detail = site.data.agents.corporate_entities[{{id}}] %}
+          {% assign agent_detail = site.data.agents.corporate_entities[id] %}
         {% elsif agent.ref contains "families" %}
           {% assign schtype = "Person" %}
           {% assign type = "families" %}
           {% assign label = "familyName" %}
           {% capture id %}{{agent.ref | replace: '/agents/families/', '' }}{% endcapture %}
-          {% assign agent_detail = site.data.agents.families[{{id}}] %}
+          {% assign agent_detail = site.data.agents.families[id] %}
         {% elsif agent.ref contains "people" %}
           {% assign schtype = "Person" %}
           {% assign type = "people" %}
           {% assign label = "name" %}
           {% capture id %}{{agent.ref | replace: '/agents/people/', '' }}{% endcapture %}
-          {% assign agent_detail = site.data.agents.people[{{id}}] %}
+          {% assign agent_detail = site.data.agents.people[id] %}
         {% endif %}
       {% else %}
         {% assign agent_detail = agent %}
@@ -66,19 +66,19 @@
           {% assign type = "organizations" %}
           {% assign label = "name" %}
           {% capture id %}{{agent.ref | replace: '/agents/corporate_entities/', '' }}{% endcapture %}
-          {% assign agent_detail = site.data.agents.corporate_entities[{{id}}] %}
+          {% assign agent_detail = site.data.agents.corporate_entities[id] %}
         {% elsif agent.ref contains "families" %}
           {% assign schtype = "Person" %}
           {% assign type = "families" %}
           {% assign label = "familyName" %}
           {% capture id %}{{agent.ref | replace: '/agents/families/', '' }}{% endcapture %}
-          {% assign agent_detail = site.data.agents.families[{{id}}] %}
+          {% assign agent_detail = site.data.agents.families[id] %}
         {% elsif agent.ref contains "people" %}
           {% assign schtype = "Person" %}
           {% assign type = "people" %}
           {% assign label = "name" %}
           {% capture id %}{{agent.ref | replace: '/agents/people/', '' }}{% endcapture %}
-          {% assign agent_detail = site.data.agents.people[{{id}}] %}
+          {% assign agent_detail = site.data.agents.people[id] %}
         {% endif %}
       {% else %}
         {% assign agent_detail = agent %}
@@ -114,19 +114,19 @@
           {% assign type = "organizations" %}
           {% assign label = "name" %}
           {% capture id %}{{agent.ref | replace: '/agents/corporate_entities/', '' }}{% endcapture %}
-          {% assign agent_detail = site.data.agents.corporate_entities[{{id}}] %}
+          {% assign agent_detail = site.data.agents.corporate_entities[id] %}
         {% elsif agent.ref contains "families" %}
           {% assign schtype = "Person" %}
           {% assign type = "families" %}
           {% assign label = "familyName" %}
           {% capture id %}{{agent.ref | replace: '/agents/families/', '' }}{% endcapture %}
-          {% assign agent_detail = site.data.agents.families[{{id}}] %}
+          {% assign agent_detail = site.data.agents.families[id] %}
         {% elsif agent.ref contains "people" %}
           {% assign schtype = "Person" %}
           {% assign type = "people" %}
           {% assign label = "name" %}
           {% capture id %}{{agent.ref | replace: '/agents/people/', '' }}{% endcapture %}
-          {% assign agent_detail = site.data.agents.people[{{id}}] %}
+          {% assign agent_detail = site.data.agents.people[id] %}
         {% endif %}
       {% else %}
         {% assign agent_detail = agent %}
@@ -156,7 +156,7 @@
     {% for subject in subjects %}
       {% if subject.ref %}
         {% capture subject_id %}{{subject.ref | replace: '/subjects/', ''}}{% endcapture %}
-        {% assign subject_detail = site.data.subjects[{{subject_id}}] %}
+        {% assign subject_detail = site.data.subjects[subject_id] %}
       {% else %}
         {% assign subject_detail = subject %}
       {% endif %}

--- a/site/_includes/component.html
+++ b/site/_includes/component.html
@@ -3,7 +3,7 @@
 {% endif %}
 {% for component in tree %}
   {% capture component_id %}{{component.id}}{% endcapture %}
-  {% assign component_detail = site.data.objects[{{component_id}}] %}
+  {% assign component_detail = site.data.objects[component_id] %}
 
   <div class="col-md-12 {{component.level}}">
     <div id="{{component_detail.ref_id}}" class="row">

--- a/site/_includes/subjects.html
+++ b/site/_includes/subjects.html
@@ -2,7 +2,7 @@
     {% if subject.ref %}
         <!-- there is an external .json file to read subject_detail from -->
         {% capture subject_id %}{{subject.ref | replace: '/subjects/', ''}}{% endcapture %}
-        {% assign subject_detail = site.data.subjects[{{subject_id}}] %}
+        {% assign subject_detail = site.data.subjects[subject_id] %}
     {% else %}
         <!-- there is no external .json file - just use subject as subject_detail -->
         {% assign subject_detail = subject %}

--- a/site/_layouts/collections.html
+++ b/site/_layouts/collections.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 {% capture collection_id %}{{page.id}}{% endcapture %}
-{% assign collection = site.data.collections[{{collection_id}}] %}
+{% assign collection = site.data.collections[collection_id] %}
 {% capture fa_number %}{{ collection.id_0 }}{% if collection.id_1 %}.{{ collection.id_1 }}{% endif %}{% if collection.id_2 %}.{{ collection.id_2 }}{% endif %}{% if collection.id_3 %}.{{ collection.id_3 }}{% endif %}{% endcapture %}
 
 <div class="col-md-8 col-md-offset-2">
@@ -41,7 +41,7 @@ layout: default
   {% if collection.tree.ref %}
     <h3 id="{{collection.id_0}}-contents">Contents</h3>
     <div class="collection contents">
-      {% assign tree = site.data.trees[{{collection_id}}].children %}
+      {% assign tree = site.data.trees[collection_id].children %}
       {% include component.html %}
     </div>
   {% endif %}

--- a/site/_layouts/families.html
+++ b/site/_layouts/families.html
@@ -2,6 +2,6 @@
 layout: default
 ---
 {% capture family_id %}{{page.id}}{% endcapture %}
-{% assign agent = site.data.agents.families[{{family_id}}] %}
+{% assign agent = site.data.agents.families[family_id] %}
 
 {% include agent.html %}

--- a/site/_layouts/objects.html
+++ b/site/_layouts/objects.html
@@ -2,8 +2,8 @@
 layout: default
 ---
 {% capture object_id %}{{page.id}}{% endcapture %}
-{% assign object = site.data.objects[{{object_id}}] %}
-{% assign breadcrumbs = site.data.breadcrumbs[{{object_id}}] %}
+{% assign object = site.data.objects[object_id] %}
+{% assign breadcrumbs = site.data.breadcrumbs[object_id] %}
 
 <div class="col-md-8 col-md-offset-2">
 

--- a/site/_layouts/organizations.html
+++ b/site/_layouts/organizations.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 {% capture organization_id %}{{page.id}}{% endcapture %}
-{% assign agent = site.data.agents.corporate_entities[{{organization_id}}] %}
+{% assign agent = site.data.agents.corporate_entities[organization_id] %}
 
 {% include agent.html %}
 

--- a/site/_layouts/people.html
+++ b/site/_layouts/people.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 {% capture person_id %}{{page.id}}{% endcapture %}
-{% assign agent = site.data.agents.people[{{person_id}}] %}
+{% assign agent = site.data.agents.people[person_id] %}
 
 {% include agent.html %}
 

--- a/site/_layouts/software.html
+++ b/site/_layouts/software.html
@@ -2,6 +2,6 @@
 layout: default
 ---
 {% capture software_id %}{{page.id}}{% endcapture %}
-{% assign software = site.data.agents.software[{{software_id}}] %}
+{% assign software = site.data.agents.software[software_id] %}
 
 {% include agent.html %}

--- a/site/feed.xml
+++ b/site/feed.xml
@@ -1,5 +1,5 @@
 ---
-layout: null
+layout: none
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">

--- a/site/search_data.json
+++ b/site/search_data.json
@@ -1,5 +1,5 @@
 ---
-layout: null
+layout: none
 ---
 {
   {% assign collection_data = site.data.collections %}
@@ -15,7 +15,7 @@ layout: null
         {% assign subjects = collection.subjects %}
         {% for subject in subjects %}
           {% capture subject_id %}{{ subject.ref | replace: '/subjects/', ''}}{% endcapture %}
-          {% assign subject_detail = site.data.subjects[{{subject_id}}] %}
+          {% assign subject_detail = site.data.subjects[subject_id] %}
           "{{subject_detail.title}}"{% unless forloop.last %},{% endunless %}
         {% endfor %}
       ]
@@ -34,7 +34,7 @@ layout: null
         {% assign subjects = object.subjects %}
         {% for subject in subjects %}
           {% capture subject_id %}{{ subject.ref | replace: '/subjects/', ''}}{% endcapture %}
-          {% assign subject_detail = site.data.subjects[{{subject_id}}] %}
+          {% assign subject_detail = site.data.subjects[subject_id] %}
           "{{subject_detail.title}}"{% unless forloop.last %},{% endunless %}
         {% endfor %}
       ]


### PR DESCRIPTION
Includes a number of updates for Jekyll 3.5 including:

- Replaces number in title of `404.html` with a string
- Removes double curly brackets inside square brackets (Liquid 4 update)
- Replaces `layout: null` with `layout: none`

For more information see [Jekyll 3.5 release notes](https://jekyllrb.com/docs/history/).